### PR TITLE
chore(gradle): rename root project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 }
 
 group = "com.factset.sdk.streaming"
-val artifact = "factsettrading"
 version = "1.0-SNAPSHOT"
 
 repositories {
@@ -45,7 +44,6 @@ tasks.compileJava {
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {
-            artifactId = artifact
 
             // dependencies
             from(components["java"])

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,2 @@
-rootProject.name = "enterprise-sdk-streaming-order-updates"
+rootProject.name = "factsettrading"
 


### PR DESCRIPTION
to and align it with the maven artifactId

### Description

Renamed the gradle project to "factsettrading" which automatically sets the Maven artifactId to that value as well.

### Links


### Testing


### Checklist

Ensure the following things have been met before requesting a review:

* [x] Follows all project developer guide and coding standards.
* [x] Tests have been written for the change, when applicable.
* [x] Confidential information (credentials, auth tokens, etc...) is not included.
